### PR TITLE
Fix uploaded image node collapsing to nothing on workflow reload

### DIFF
--- a/components/nodes/ImageInputNode.tsx
+++ b/components/nodes/ImageInputNode.tsx
@@ -240,8 +240,6 @@ export default function ImageInputNode({ id, data, selected }: NodeProps<ImageIn
         className={`node-card group${(data.hasError as boolean) ? " node-error-blink" : ""}`}
         style={{
           width: "100%",
-          // Floor the width so a node that was persisted with a 0/undefined width
-          // (older bug) still renders and self-heals via the ResizeObserver below.
           minWidth: 120,
           aspectRatio: ratio,
           background: "transparent",

--- a/components/nodes/ImageInputNode.tsx
+++ b/components/nodes/ImageInputNode.tsx
@@ -240,6 +240,9 @@ export default function ImageInputNode({ id, data, selected }: NodeProps<ImageIn
         className={`node-card group${(data.hasError as boolean) ? " node-error-blink" : ""}`}
         style={{
           width: "100%",
+          // Floor the width so a node that was persisted with a 0/undefined width
+          // (older bug) still renders and self-heals via the ResizeObserver below.
+          minWidth: 120,
           aspectRatio: ratio,
           background: "transparent",
         }}


### PR DESCRIPTION
## Problem

When a workflow was left and reopened, an uploaded image no longer displayed in its Image node — even though the asset had persisted correctly and could be seen loading over the network (200) in the devtools Network tab.

## Root cause

On reload, the image node's width was restored as `0`. Because the node card is sized with `width: 100%` and derives its height from `aspect-ratio`, a `0` width collapsed the whole card to `0×0`. The `<img>` still fetched its source (hence the network request), but rendered invisibly.

This was **not** a persistence, Supabase, or upload issue — the `r2Url` was saved and served fine.

## Fix

Floor the image node width with `minWidth: 120`. The node now always renders with a non-zero width, and the existing `ResizeObserver` re-measures and re-persists the real width on mount. This also **self-heals** nodes that were already stored with a `0` width from before the fix.

## Testing

- Upload an image into a workflow node
- Leave the workflow and return → the image now displays correctly instead of collapsing to an empty node

🤖 Generated with [Claude Code](https://claude.com/claude-code)