### PR TITLE
fix: Guest Mode reference URLs unreachable by kie.ai over ngrok

### DIFF
--- a/lib/guest/localStorage.ts
+++ b/lib/guest/localStorage.ts
@@ -65,8 +65,23 @@ export async function uploadDataUrl(dataUrl: string, folder: string): Promise<st
   return uploadBuffer(Buffer.from(m[2], "base64"), m[1], folder);
 }
 
+/** Kie.ai fetches this over the internet, so a bare "/generated/..." path
+ *  won't resolve — prefix with the public tunnel URL (e.g. ngrok) when set.
+ *  Only used for outbound reference URLs, never for stored results (those
+ *  must stay same-origin so the browser doesn't have to cross the tunnel). */
+function toPublicUrl(path: string, base = process.env.CALLBACK_BASE_URL?.replace(/\/$/, "")): string {
+  return base && path.startsWith("/") ? `${base}${path}` : path;
+}
+
 export async function ensureStorage(url: string, folder: string): Promise<string> {
-  if (url.startsWith("data:"))        return uploadDataUrl(url, folder);
-  if (url.startsWith("/generated/")) return url;
-  return mirrorToStorage(url, folder);
+  const base = process.env.CALLBACK_BASE_URL?.replace(/\/$/, "");
+  if (base && url.startsWith(`${base}/generated/`)) return url; // already public
+
+  const stored = url.startsWith("data:")
+    ? await uploadDataUrl(url, folder)
+    : url.startsWith("/generated/")
+    ? url
+    : await mirrorToStorage(url, folder);
+
+  return toPublicUrl(stored, base);
 }


### PR DESCRIPTION
## Summary
- In Guest Mode, reference images/videos/audio are stored locally and resolved to a relative `/generated/...` URL. That's fine for the browser (same-origin) but kie.ai runs on the internet and can't fetch a relative path — any generation using a reference (image-to-video, start/end frame, reference images) failed with `Upload failed: Server internal error`, even with `CALLBACK_BASE_URL` (ngrok) correctly set, since only the callback endpoint was exposed publicly.
- `ensureStorage()` now prefixes outbound reference URLs with `CALLBACK_BASE_URL` so kie.ai can fetch them.
- Stored *results* (mirrored back from kie.ai for local display via `mirrorToStorage`/`uploadBuffer`) are untouched and stay relative — routing those through the ngrok tunnel instead would hit ngrok free tier's browser-warning interstitial on cross-site `<video>`/`<img>` requests and silently break playback in the gallery.

## Test plan
- [x] Guest Mode + ngrok: image-to-video generation with a reference image now succeeds on kie.ai's side (previously failed with `Upload failed: Server internal error`)
- [x] Generated video/image still renders correctly in the local gallery (same-origin, no ngrok interstitial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)