### PR TITLE
fix: 403 on asset downloads in Guest Mode

### DIFF
--- a/app/api/download/route.ts
+++ b/app/api/download/route.ts
@@ -6,6 +6,7 @@
  * Only allowed origins are proxied.
  */
 import { NextRequest, NextResponse } from "next/server";
+import { GUEST_MODE } from "@/lib/guestMode";
 
 const ALLOWED_ORIGINS = [
   process.env.R2_PUBLIC_URL ?? "",
@@ -16,6 +17,7 @@ const ALLOWED_ORIGINS = [
 ].filter(Boolean).map((o) => o.replace(/\/$/, ""));
 
 function isAllowed(url: string): boolean {
+  if (GUEST_MODE && url.startsWith("/generated/")) return true; // local disk, served same-origin
   return ALLOWED_ORIGINS.some((origin) => url.startsWith(origin));
 }
 
@@ -28,9 +30,18 @@ export async function GET(req: NextRequest) {
   if (!url) return new NextResponse("Missing url", { status: 400 });
   if (!isAllowed(url)) return new NextResponse("Forbidden", { status: 403 });
 
+  let fetchUrl = url;
+  if (GUEST_MODE && url.startsWith("/generated/")) {
+    const resolved = new URL(url, req.nextUrl.origin);
+    // Re-check after normalization: rejects "/generated/../api/..." traversal
+    // that would otherwise turn this proxy into same-origin SSRF.
+    if (!resolved.pathname.startsWith("/generated/")) return new NextResponse("Forbidden", { status: 403 });
+    fetchUrl = resolved.toString();
+  }
+
   let upstream: Response;
   try {
-    upstream = await fetch(url);
+    upstream = await fetch(fetchUrl);
   } catch {
     return new NextResponse("Fetch failed", { status: 502 });
   }


### PR DESCRIPTION
## Summary
- `/api/download` proxies asset fetches through an origin allowlist (R2, kie.ai, replicate) to guard against SSRF. In Guest Mode, generated/uploaded files live on local disk and are served at a relative `/generated/...` path — not in that allowlist, so every download click returned `403 Forbidden`.
- Local-file exception is gated on `GUEST_MODE` (not just URL shape) so it stays inert in cloud/R2 deployments.
- Re-checks the resolved pathname after building the absolute fetch URL — the raw prefix check alone would let `/generated/../api/...` resolve to an internal route, turning the download proxy into same-origin SSRF.

## Test plan
- [x] Guest Mode: clicking download on a generated video/image now returns the file instead of 403
- [x] `/generated/../...` style paths rejected with 403
- [ ] Maintainer smoke test on cloud/R2 mode (should be unaffected — gated on `GUEST_MODE`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)