### PR TITLE
fix: file drag-and-drop from Finder/Explorer (three stacked issues)

### DIFF
--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -3285,6 +3285,21 @@ function GalleryInner() {
       {/* ── Prompt bar ── */}
       <div
         ref={promptBarRef}
+        onDragOver={e => {
+          // OS file drag (Finder/Explorer): make the WHOLE prompt bar a drop target.
+          if (Array.from(e.dataTransfer.types).includes("Files")) {
+            e.preventDefault();
+            e.stopPropagation();
+            e.dataTransfer.dropEffect = "copy";
+          }
+        }}
+        onDrop={e => {
+          if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+            e.preventDefault();
+            e.stopPropagation();
+            handleFilePick(e.dataTransfer.files);
+          }
+        }}
         style={{
           position: "fixed",
           bottom: "32px",

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -3597,6 +3597,21 @@ function GalleryInner() {
                 data-prompt-input=""
                 value={prompt}
                 rows={1}
+                onDragOver={e => {
+                  // Textareas are NATIVE drop targets: without explicit handlers WebKit grabs
+                  // file drags itself (expanded mode = the textarea covers the whole bar).
+                  if (Array.from(e.dataTransfer.types).includes("Files")) {
+                    e.preventDefault();
+                    e.dataTransfer.dropEffect = "copy";
+                  }
+                }}
+                onDrop={e => {
+                  if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    handleFilePick(e.dataTransfer.files);
+                  }
+                }}
                 onChange={e => {
                   const text = e.target.value;
                   const cursor = e.target.selectionStart ?? text.length;
@@ -3784,6 +3799,22 @@ function GalleryInner() {
                           data-prompt-input=""
                           placeholder={blockIdx === 0 && !isNonEmpty ? "Describe the scene you imagine…" : undefined}
                           onClick={e => { if (isExpanded) e.stopPropagation(); }}
+                          onDragOver={e => {
+                            // Textareas are NATIVE drop targets: without explicit handlers WebKit
+                            // grabs file drags itself (expanded mode = the textarea covers the whole
+                            // bar, so drops silently died there). Route files to the composer.
+                            if (Array.from(e.dataTransfer.types).includes("Files")) {
+                              e.preventDefault();
+                              e.dataTransfer.dropEffect = "copy";
+                            }
+                          }}
+                          onDrop={e => {
+                            if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              handleFilePick(e.dataTransfer.files);
+                            }
+                          }}
                           onFocus={e => {
                             activeBlockRef.current = e.currentTarget;
                             activeBlockIdxRef.current = blockIdx;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import UpdateBanner from "@/components/UpdateBanner";
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { cookies } from "next/headers";
+import { DragDropGuard } from "@/components/DragDropGuard";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -60,7 +61,8 @@ export default async function RootLayout({
               <div className="md:hidden flex items-center h-10 px-3 border-b border-white/[0.08] shrink-0">
                 <SidebarTrigger className="text-white/50 hover:text-white hover:bg-white/[0.05] transition-colors rounded-lg p-1.5 [&_svg]:size-4" />
               </div>
-              {children}
+              <DragDropGuard />
+        {children}
             </SidebarInset>
           </SidebarProvider>
         </TooltipProvider>

--- a/components/DragDropGuard.tsx
+++ b/components/DragDropGuard.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Without this, a file dropped outside a handled drop zone makes the webview
+// NAVIGATE to the file (the window "becomes" the image) — especially in the
+// desktop build now that Tauri's drag-drop interception is disabled and HTML5
+// drops reach the webview. Component-level onDrop handlers still run first on
+// their own targets; this only kills the default navigate-on-drop everywhere.
+export function DragDropGuard() {
+  useEffect(() => {
+    const prevent = (e: DragEvent) => {
+      e.preventDefault();
+    };
+    window.addEventListener("dragover", prevent);
+    window.addEventListener("drop", prevent);
+    return () => {
+      window.removeEventListener("dragover", prevent);
+      window.removeEventListener("drop", prevent);
+    };
+  }, []);
+  return null;
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,8 @@
         "minHeight": 600,
         "resizable": true,
         "fullscreen": false,
-        "url": "index.html"
+        "url": "index.html",
+        "dragDropEnabled": false
       }
     ],
     "security": {
@@ -36,8 +37,12 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "externalBin": ["binaries/helios-node"],
-    "resources": ["server/**/*"],
+    "externalBin": [
+      "binaries/helios-node"
+    ],
+    "resources": [
+      "server/**/*"
+    ],
     "category": "GraphicsAndDesign",
     "shortDescription": "Build AI image & video pipelines visually.",
     "longDescription": "HeliosGen is a local-first visual workflow builder for AI image and video generation. All data stays on your machine.",


### PR DESCRIPTION
Dragging an image from the OS onto the app did nothing in the desktop build (and could even make the window navigate to the file). It turned out to be **three stacked issues**, each hiding the next one — fixed in three commits:

### 1. Tauri swallows HTML5 file drops
`dragDropEnabled` defaults to `true`, so the shell intercepts OS drags and the webview never receives HTML5 `drop` events — while the exact same UI works in a browser. Fixed by setting `"dragDropEnabled": false` in `tauri.conf.json` (the UI already has full `onDrop` handlers in WorkflowCanvas / Image & VideoInputNode, so the Tauri-native drag-drop events aren't needed).

### 2. Drops outside a handled zone navigate the webview
Once drops reach the webview, a file dropped outside a valid target triggers the default navigate-to-file — the window "becomes" the image. Added a small `DragDropGuard` (window-level `dragover`/`drop` `preventDefault`) in the root layout. Component handlers keep working.

### 3. The prompt bar ignored real files
The composer's drop handlers only accepted internal gallery drags (`application/x-gallery-item`) and explicitly returned on anything else — so Finder files were ignored even when they reached the right zone. The whole prompt bar is now a drop target: OS files are routed through the existing `handleFilePick` (same path as the IMAGE button), respecting the model's image support and remaining-slots limit.

**Tested** on macOS (Apple Silicon), local `npm run desktop:build`: dropping an image anywhere on the prompt bar attaches it as a reference image with the usual upload spinner; drops elsewhere are inert; browser/web behavior unchanged.

Related: #12 (bundle version not bumped — made verifying the fix build harder). Thanks for the app! 🙏