### PR TITLE
fix(desktop): bump version to 1.2.0 and guard it against drift (#12)

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,30 @@
+name: version-check
+
+# Guards against issue #12: a release tag whose bundle version was never bumped
+# in src-tauri/tauri.conf.json. On PRs it only checks that the version files
+# agree; on a vX.Y.Z / X.Y.Z tag it also checks the tag matches.
+
+on:
+  push:
+    branches: [main]
+    tags: ["*"]
+  pull_request:
+    paths:
+      - "package.json"
+      - "src-tauri/tauri.conf.json"
+      - "src-tauri/Cargo.toml"
+      - "src-tauri/Cargo.lock"
+      - "scripts/desktop/check-version.mjs"
+      - ".github/workflows/version-check.yml"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      # GITHUB_REF_NAME is the tag on a tag push, the branch otherwise; the
+      # script ignores anything that isn't a X.Y.Z version string.
+      - run: node scripts/desktop/check-version.mjs

--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -108,7 +108,7 @@ disable-library-validation — the bundled Node/V8 needs them).
 Verify the result:
 ```bash
 spctl -a -vvv "src-tauri/target/release/bundle/macos/HeliosGen.app"   # → accepted, source=Notarized Developer ID
-xcrun stapler validate "src-tauri/target/release/bundle/dmg/HeliosGen_0.1.0_aarch64.dmg"
+xcrun stapler validate "src-tauri/target/release/bundle/dmg/HeliosGen_1.2.0_aarch64.dmg"
 ```
 
 ## Local data store
@@ -157,14 +157,20 @@ plus every referenced image/video — portable and shareable as a file
       native-module signing in `build-server.mjs`); needs a Developer ID cert to
       actually run.
 - [x] Update check — `app/api/update-check/route.ts` asks the GitHub Releases
-      API (`repos/SegFault42/WorkflowAI/releases/latest`, cached ~1 h) whether
+      API (`repos/SegFault42/HeliosGen/releases/latest`, cached ~1 h) whether
       `tag_name` is newer than `NEXT_PUBLIC_APP_VERSION` (baked from
       `tauri.conf.json` by `build-server.mjs` / `dev.mjs`). When it is,
       `components/UpdateBanner.tsx` shows a yellow "Update available" bar under
       the Kie banner; tapping it opens a modal with the release notes and a
       **Download** button (opens the release page via the external-link handler).
-      No self-install. Cut a release by tagging `vX.Y.Z` on GitHub with `version`
-      bumped in `tauri.conf.json` to match.
+      No self-install. Cut a release by bumping `version` in `tauri.conf.json`,
+      `package.json`, `src-tauri/Cargo.toml` and `src-tauri/Cargo.lock` (the
+      `heliosgen-desktop` entry) to the same `X.Y.Z`, then `node
+      scripts/desktop/check-version.mjs X.Y.Z` to confirm they agree. Commit,
+      then tag `vX.Y.Z`. Tauri bakes `tauri.conf.json` `version` into the macOS
+      Info.plist / Windows installer and into `NEXT_PUBLIC_APP_VERSION`. `npm run
+      desktop:build` runs the check first, and the `version-check` CI job fails
+      any tag push whose version files disagree (issue #12).
       `NEXT_PUBLIC_UPDATE_CHECK_FORCE=1` (dev) forces the banner on for eyeballing.
 - [ ] Bundle size — was ~330 MB stage / ~440 MB `.app`; dropping `@aws-sdk` +
       `@supabase` (~web/cloud removal) should trim it further. Remaining bulk is

--- a/app/api/update-check/route.ts
+++ b/app/api/update-check/route.ts
@@ -12,7 +12,7 @@ import { NextResponse } from "next/server";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const REPO = "SegFault42/WorkflowAI";
+const REPO = "SegFault42/HeliosGen";
 const RELEASES_API = `https://api.github.com/repos/${REPO}/releases/latest`;
 const RELEASES_PAGE = `https://github.com/${REPO}/releases/latest`;
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1h — GitHub unauthenticated limit is 60/h

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heliosgen",
-  "version": "0.1.0",
+  "version": "1.2.0",
   "private": true,
   "packageManager": "pnpm@9.15.9",
   "scripts": {
@@ -9,7 +9,8 @@
     "start": "next start -p ${PORT:-3000}",
     "lint": "eslint",
     "desktop:dev": "node scripts/desktop/dev.mjs",
-    "desktop:build": "CI=true tauri build",
+    "desktop:check-version": "node scripts/desktop/check-version.mjs",
+    "desktop:build": "node scripts/desktop/check-version.mjs && CI=true tauri build",
     "desktop:icon": "tauri icon",
     "tauri": "tauri"
   },

--- a/scripts/desktop/check-version.mjs
+++ b/scripts/desktop/check-version.mjs
@@ -1,0 +1,87 @@
+// Verifies the app version is consistent across every file that carries it,
+// and — when given a release tag — that the tag matches too.
+//
+//   node scripts/desktop/check-version.mjs            # cross-file consistency
+//   node scripts/desktop/check-version.mjs 1.2.0      # …and must equal 1.2.0
+//   node scripts/desktop/check-version.mjs v1.2.0     # leading "v" is tolerated
+//
+// In CI the tag is read from $GITHUB_REF_NAME when no argument is passed, so a
+// `git push --tags` that forgets to bump `tauri.conf.json` fails the build
+// instead of shipping a bundle stamped with the wrong CFBundleShortVersionString
+// (see issue #12).
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+// tauri.conf.json is the source of truth — Tauri bakes its `version` into the
+// macOS Info.plist, the Windows installer, and NEXT_PUBLIC_APP_VERSION.
+const SOURCES = [
+  {
+    file: "src-tauri/tauri.conf.json",
+    read: (t) => JSON.parse(t).version,
+  },
+  {
+    file: "package.json",
+    read: (t) => JSON.parse(t).version,
+  },
+  {
+    file: "src-tauri/Cargo.toml",
+    read: (t) => t.match(/^\s*\[package\][\s\S]*?^\s*version\s*=\s*"([^"]+)"/m)?.[1],
+  },
+  {
+    file: "src-tauri/Cargo.lock",
+    read: (t) =>
+      t.match(/name = "heliosgen-desktop"\nversion = "([^"]+)"/)?.[1],
+  },
+];
+
+const found = SOURCES.map(({ file, read }) => {
+  let version;
+  try {
+    version = read(readFileSync(join(ROOT, file), "utf8"));
+  } catch (err) {
+    console.error(`✗ ${file}: could not read (${err.message})`);
+    process.exitCode = 1;
+    return { file, version: null };
+  }
+  if (!version) {
+    console.error(`✗ ${file}: no version found`);
+    process.exitCode = 1;
+  }
+  return { file, version };
+});
+
+const canonical = found[0].version;
+let ok = Boolean(canonical);
+
+for (const { file, version } of found) {
+  if (version && version !== canonical) {
+    console.error(`✗ ${file}: ${version} (expected ${canonical})`);
+    ok = false;
+  } else if (version) {
+    console.log(`✓ ${file}: ${version}`);
+  }
+}
+
+const rawTag = process.argv[2] || process.env.GITHUB_REF_NAME || "";
+const tag = rawTag.replace(/^v/, "").trim();
+if (tag && /^\d+\.\d+\.\d+/.test(tag)) {
+  if (tag !== canonical) {
+    console.error(
+      `✗ release tag ${rawTag} does not match version ${canonical} — bump ` +
+        `src-tauri/tauri.conf.json (and package.json / Cargo.toml / Cargo.lock)`,
+    );
+    ok = false;
+  } else {
+    console.log(`✓ release tag ${rawTag} matches`);
+  }
+}
+
+if (!ok) {
+  process.exitCode = 1;
+} else {
+  console.log(`\nversion OK: ${canonical}`);
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1246,7 +1246,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heliosgen-desktop"
-version = "0.1.0"
+version = "1.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heliosgen-desktop"
-version = "0.1.0"
+version = "1.2.0"
 description = "HeliosGen desktop app"
 authors = ["HeliosGen"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "HeliosGen",
-  "version": "0.1.0",
+  "version": "1.2.0",
   "identifier": "cash.sdd.helios.desktop",
   "build": {
     "beforeDevCommand": "node scripts/desktop/build-server.mjs --dev",


### PR DESCRIPTION
The 1.1.0 release shipped an app bundle stamped 0.1.0 — nobody bumped `version` in `src-tauri/tauri.conf.json`, which Tauri bakes into the macOS Info.plist, the Windows installer, and `NEXT_PUBLIC_APP_VERSION`. Version comparison (updater, support) saw every build as identical.

- bump `version` to 1.2.0 in tauri.conf.json, package.json, Cargo.toml, Cargo.lock
- add `scripts/desktop/check-version.mjs`: fails if the version files disagree, or (given a tag) if a release tag doesn't match the bundle version
- run the check before `npm run desktop:build`
- add a `version-check` GitHub Actions workflow that runs on PRs and tag pushes
- point the in-app update check at `SegFault42/HeliosGen` (was the pre-rename `WorkflowAI`, so it never saw real releases)
- document the release bump steps in DESKTOP.md